### PR TITLE
test: fix test dependencies

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,9 @@
 import React from 'react';
+import Sharebar from '../src';
 import TestUtils from 'react-addons-test-utils';
 import chai from 'chai';
 import chaiSpies from 'chai-spies';
 chai.use(chaiSpies).should();
-
-import Sharebar from '..';
 
 describe('Sharebar', () => {
   it('renders a React element', () => {

--- a/test/sharebar-icon.js
+++ b/test/sharebar-icon.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import chai from 'chai';
+import SharebarIcon from '../src/sharebar-icon';
 import TestUtils from 'react-addons-test-utils';
+import chai from 'chai';
 chai.should();
-
-import SharebarIcon, { handleClick } from '../sharebar-icon';
-import Icon from '@economist/component-icon';
 
 describe('Sharebar Icon', () => {
   it('renders a React element', () => {
@@ -39,4 +37,3 @@ describe('Sharebar Icon', () => {
     });
   });
 });
-


### PR DESCRIPTION
Builds are currently failing because, during the reprovision, test dependencies weren't correctly setup. This fixes that, and should get the build passing again.

For posterity: 

```js
10:11:33.119 Error: Cannot find module '../sharebar-icon' from '/code/test'
10:11:33.119     at /code/node_modules/browserify/node_modules/resolve/lib/async.js:55:21
10:11:33.119     at load (/code/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
10:11:33.119     at onex (/code/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
10:11:33.119     at /code/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
10:11:33.119     at FSReqWrap.oncomplete (fs.js:82:15)
10:11:33.128 
```