### PR TITLE
chore(build): drop babel runtime option

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,6 @@
     "compact": false,
     "ignore": "node_modules",
     "loose": "all",
-    "optional": [
-      "runtime"
-    ],
     "sourceMaps": "inline",
     "stage": 2
   },


### PR DESCRIPTION
Missed this one. This will fix broken build.