### PR TITLE
WP-256 fix: changed twitter url from intent to share

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const iconProps = {
   },
   twitter: {
     title: 'Share on Twitter',
-    url: 'https://twitter.com/intent/tweet?url=',
+    url: 'https://twitter.com/share?url=',
   },
   googleplus: {
     title: 'Share on Google Plus',


### PR DESCRIPTION
Twitter share button url was set to intent url which is meant to be open as a separate popup window (doc source: https://dev.twitter.com/web/tweet-button ), since we want to open it as a single tab it is changed to older share functionality.