### PR TITLE
wp-1697 fix(icon): remove follow option from sharebar icon i13n

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,13 @@ export default function Sharebar({
       <div className="share-component__icons">
         {icons.map((icon, index) => {
           const I13nShareBarIcon =
-              typeof i13nFunction === 'undefined' ? SharebarIcon : i13nFunction.generateI13nNode(SharebarIcon, true);
+              typeof i13nFunction === 'undefined' ?
+                SharebarIcon :
+                i13nFunction.generateI13nNode(
+                  SharebarIcon,
+                  true,
+                  { props: { follow: false } }
+                );
           return (<I13nShareBarIcon
             key={icon}
             icon={slugCamelCase(icon)}


### PR DESCRIPTION
The `generateI13nNode` function is defined like so:

```javascript
export function generateI13nNode(node, isLink = false) {
  return createI13nNode(
    node,
    {
      isLeafNode: isLink,
      bindClickEvent: isLink,
      follow: isLink,
    },
    {
      skipUtilFunctionsByProps: isLink,
    }
  );
}
```

The second argument is used to set four different configuration properties, which is probably ok in most cases, but it does not allow for an override. I have changed the implementation in fe-blogs to allow override.